### PR TITLE
proot error fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Prepereqisites:
 To run Ansible Tower there is two ways:
 Create container without external data mounts so if you remove container, all Postgres data that used by AT is lost:
 ```
-# docker run -t -d -p 443:443 -p 8080:8080 -v ~/certs:/certs -e SERVER_NAME=localhost --name=ast ybalt/ansible-tower
+# docker run --privileged -t -d -p 443:443 -p 8080:8080 -v ~/certs:/certs -e SERVER_NAME=localhost --name=ast ybalt/ansible-tower
 ```
 OR
 Create separate data-only container, it will save your DB data even if ast container removed(upgrade, etc):
 ```
 # docker create -v /var/lib/postgresql/9.4/main --name astdata ybalt/ansible-tower /bin/true
-# docker run -t -d --volumes-from astdata -v ~/certs:/certs -e SERVER_NAME=localhost -p 443:443 --name=ast ybalt/ansible-tower
+# docker run --privileged -t -d --volumes-from astdata -v ~/certs:/certs -e SERVER_NAME=localhost -p 443:443 --name=ast ybalt/ansible-tower
 ```
 
 You may use mapping for /certs as above, to add certificate and license file. Startup script will copy files with this filenames to /etc/tower:


### PR DESCRIPTION
When running the container without --privileged on Linux 3.10.0-229.el7.x86_64 (Tried on CentOS 7) gives the following error during job execution:
proot error: ptrace(TRACEME): Operation not permitted
proot error: execve("/usr/bin/ansible-playbook"): Operation not permitted
proot info: It seems your kernel contains this bug: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1202161
To workaround it, set the env. variable PROOT_NO_SECCOMP to 1.
fatal error: see `proot --help`.
proot error: can't chmod '/tmp/proot-697-LpbA1y': No such file or directory

Looking at the kernel bugs and fixes it has been recognized as a kernel issue.
In order to resolve the same, starting up the container with --privileged will help running the jobs.