### PR TITLE
 Updated PostgreSQL data directory to version 9.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer mittell@gmail.com, reuben.stump@gmail.com, ybaltouski@gmail.com
 WORKDIR /opt
 
 ENV ANSIBLE_TOWER_VER 3.2.1
-ENV PG_DATA /var/lib/postgresql/9.4/main
+ENV PG_DATA /var/lib/postgresql/9.6/main
 
 RUN apt-get update
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ docker run -t -d -v ~/certs:/certs -p 443:443 -e SERVER_NAME=localhost  ansible-
 
 To persist Ansible Tower database, create a data container:
 ```
-docker create -v /var/lib/postgresql/9.4/main --name tower-data ybalt/ansible-tower /bin/true
+docker create -v /var/lib/postgresql/9.6/main --name tower-data ybalt/ansible-tower /bin/true
 docker run -d -p 443:443 --name tower --volumes-from tower-data ybalt/ansible-tower
 ```
 or use create a Docker Volume on the host:
 ```
-docker run -d -p 443:443 -v pgdata:/var/lib/postgresql/9.4/main --name ansible-tower ybalt/ansible-tower
+docker run -d -p 443:443 -v pgdata:/var/lib/postgresql/9.6/main --name ansible-tower ybalt/ansible-tower
 ```
 
 # Certificates and License


### PR DESCRIPTION
On the latest **ubuntu:trusty** image, the expected PostgreSQL version is *9.6* already. 

This patch updates the Dockerfile and the README instructions to specify the correct mount directory.

```bash
 docker exec -it ansible-tower  ls -la /var/lib/postgresql/9.6/main/
total 96
drwx------. 20 postgres postgres 4096 Feb  7 08:20 .
drwxr-xr-x.  3 postgres postgres 4096 Dec 30 09:54 ..
-rw-------.  1 postgres postgres    4 Dec 30 09:54 PG_VERSION
drwx------.  6 postgres postgres 4096 Dec 30 09:54 base
drwx------.  2 postgres postgres 4096 Feb  7 08:21 global
drwx------.  2 postgres postgres 4096 Dec 30 09:54 pg_clog
drwx------.  2 postgres postgres 4096 Dec 30 09:54 pg_commit_ts
drwx------.  2 postgres postgres 4096 Dec 30 09:54 pg_dynshmem
drwx------.  2 postgres postgres 4096 Feb  7 05:05 pg_log
drwx------.  4 postgres postgres 4096 Dec 30 09:54 pg_logical
drwx------.  4 postgres postgres 4096 Dec 30 09:54 pg_multixact
drwx------.  2 postgres postgres 4096 Feb  7 08:20 pg_notify
drwx------.  2 postgres postgres 4096 Dec 30 09:54 pg_replslot
drwx------.  2 postgres postgres 4096 Dec 30 09:54 pg_serial
drwx------.  2 postgres postgres 4096 Dec 30 09:54 pg_snapshots
drwx------.  2 postgres postgres 4096 Dec 30 09:54 pg_stat
drwx------.  2 postgres postgres 4096 Feb  7 08:22 pg_stat_tmp
drwx------.  2 postgres postgres 4096 Dec 30 09:54 pg_subtrans
drwx------.  2 postgres postgres 4096 Dec 30 09:54 pg_tblspc
drwx------.  2 postgres postgres 4096 Dec 30 09:54 pg_twophase
drwx------.  3 postgres postgres 4096 Feb  7 05:09 pg_xlog
-rw-------.  1 postgres postgres   88 Dec 30 09:54 postgresql.auto.conf
-rw-------.  1 postgres postgres  301 Feb  7 08:20 postmaster.opts
-rw-------.  1 postgres postgres   90 Feb  7 08:20 postmaster.pid
```

Fixes: #17 