### PR TITLE
Added instructions on how to persist data under /var/lib/awx/projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ or use create a Docker Volume on the host:
 docker run -d -p 443:443 -v pgdata:/var/lib/postgresql/9.6/main --name ansible-tower ybalt/ansible-tower
 ```
 
-If you persist any Ansible project data saved at `/var/lib/awx/projects` directory, create a Docker Volume on using the command below:
+If you want to persist any Ansible project data saved at `/var/lib/awx/projects` directory, create a Docker Volume on using the command below:
 ```
 docker run -d -p 443:443 -v ~/ansible_projects:/var/lib/awx/projects --name ansible-tower ybalt/ansible-tower
 ```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ or use create a Docker Volume on the host:
 docker run -d -p 443:443 -v pgdata:/var/lib/postgresql/9.6/main --name ansible-tower ybalt/ansible-tower
 ```
 
+If you persist any Ansible project data saved at `/var/lib/awx/projects` directory, create a Docker Volume on using the command below:
+```
+docker run -d -p 443:443 -v ~/ansible_projects:/var/lib/awx/projects --name ansible-tower ybalt/ansible-tower
+```
+
 # Certificates and License
 
 The ansible-tower Docker image uses a generic certificate generated for www.ansible.com by the Ansible Tower setup


### PR DESCRIPTION
This is a simple enhancement to document how to persist the Ansible projects saved under /var/lib/awx/projects directory. 

Sometimes this is important as the user can have manually projects which can be destroyed on a new deployment. Maybe we should include this as a separate VOLUME to have consistency. If we decide to go this route, IMHO the PGDATA should be a separate volume too. 

@ybalt  what are your thoughts?