### PR TITLE
added software-properties-common to apt-get install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:16.04
 
 WORKDIR /opt
 
-ENV ANSIBLE_TOWER_VER 3.2.1
+ENV ANSIBLE_TOWER_VER 3.5.2-1
 ENV PG_DATA /var/lib/postgresql/9.6/main
 ENV AWX_PROJECTS /var/lib/awx/projects
 ENV LC_ALL "en_US.UTF-8"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get -qq update \
 	&& apt-get -yqq upgrade \
 	&& apt-get -yqq install \
 			locales \
+			software-properties-common \
 			gnupg2 \
 			gnupg \
 			libpython2.7 \


### PR DESCRIPTION
My build was failing when targeting 5.3.2-1  An unsuccessful attempt was made to add the following ppa's during the Ansible install runs.  Added software-properties-common to the initial package install in the docker file.

From the ansible ubuntu_packages role:

```
apt_repos:
    - 'ppa:ansible/ansible'
    - 'ppa:ansible/bubblewrap'
    - 'ppa:deadsnakes/ppa'
```
   