### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,9 @@ RUN cd /opt/ansible-tower-setup-${ANSIBLE_TOWER_VER} \
 	&& chmod +x /docker-entrypoint.sh
 
 # volumes and ports
-VOLUME ["${PG_DATA}", "${AWX_PROJECTS}", "/certs",]
+VOLUME "${PG_DATA}"
+VOLUME "${AWX_PROJECTS}"
+VOLUME "/certs"
 EXPOSE 443
 
 CMD ["/docker-entrypoint.sh", "ansible-tower"]


### PR DESCRIPTION
The commas seem to mess with the setup of the volume.

Please see below:
ERROR: for tower  Cannot create container for service tower: invalid bind mount spec "8c4789dbf6ad8a08925d78b70a0cdd13b6d5c393c40a052a057455f04f94ca11:[/var/lib/postgresql/9.6/main,:rw": invalid volume specification: '8c4789dbf6ad8a08925d78b70a0cdd13b6d5c393c40a052a057455f04f94ca11:[/var/lib/postgresql/9.6/main,:rw': invalid mount config for type "volume": invalid mount path: '[/var/lib/postgresql/9.6/main,' mount path must be absolute