### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY inventory inventory
 
 RUN apt-get -qq update \
 	&& apt-get -yqq upgrade \
-	&& apt-get -yqq install \
+	&& apt-get --no-install-recommends -yqq install \
 			locales \
 			gnupg2 \
 			gnupg \
@@ -28,6 +28,7 @@ RUN apt-get -qq update \
 			debconf \
 			apt-transport-https \
 			sudo \
+	&& apt-get clean \
 	&& locale-gen "en_US.UTF-8" \
 	&& echo "locales	locales/default_environment_locale	select	en_US.UTF-8" | debconf-set-selections \
 	&& dpkg-reconfigure locales \


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>