### PR TITLE
optimize size and time using "--no-cache-dir"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get -qq update \
 	&& mkdir -p /var/log/tower \
 	&& tar xvf ansible-tower-setup-${ANSIBLE_TOWER_VER}.tar.gz \
 	&& rm -f ansible-tower-setup-${ANSIBLE_TOWER_VER}.tar.gz \
-	&& pip install ansible \
+	&& pip install --no-cache-dir ansible \
 	&& mv inventory ansible-tower-setup-${ANSIBLE_TOWER_VER}/inventory
 
 RUN cd /opt/ansible-tower-setup-${ANSIBLE_TOWER_VER} \


### PR DESCRIPTION
Using "--no-cache-dir" flag in pip install ,make sure dowloaded packages
by pip don't cached on system . This is a best practise which make sure
to fetch ftom repo instead of using local cached one . Further , in case
of Docker Containers , by restricing caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6